### PR TITLE
Added new test cases with new test functions `shouldContainRegex ` `shouldCompileAndContainRegex` 

### DIFF
--- a/src/Tests/FShade.GLSL.Tests/SimpleTests.fs
+++ b/src/Tests/FShade.GLSL.Tests/SimpleTests.fs
@@ -211,16 +211,16 @@ let ``Fill Array with Inline Function``() =
     GLSL.shouldCompileAndContainRegex [ Effect.ofFunction frag ] [ expectedGLSL ]
 
 
-[<ReflectedDefinition>][<Inline>]
-let sum3 a b c =
-    a + b + c
 
 [<ReflectedDefinition>][<Inline>]
-let condSum4 (a : float) (b : float) (c : float) (d : float) =
-    if a > 0.5 then
-        sum3 (b * 2.0) c d
+let valueIdentity v = v
+
+[<ReflectedDefinition>][<Inline>]
+let condTimesTwo (v : float) =
+    if v > 0.5 then
+        valueIdentity (v * 2.0)
     else 
-        a
+        valueIdentity v
         
 [<Fact>]
 let ``Nested Double Inline``() =
@@ -229,7 +229,7 @@ let ``Nested Double Inline``() =
     let frag (v : Vertex) =
         fragment {
             
-            let v = condSum4 (uniform?a) (uniform?b) (uniform?c) (uniform?d)
+            let v = condTimesTwo (uniform?value)
 
             return V4d(v)
         }

--- a/src/Tests/FShade.GLSL.Tests/SimpleTests.fs
+++ b/src/Tests/FShade.GLSL.Tests/SimpleTests.fs
@@ -209,3 +209,29 @@ let ``Fill Array with Inline Function``() =
     ColorsOut = array\[color\];"
                 
     GLSL.shouldCompileAndContainRegex [ Effect.ofFunction frag ] [ expectedGLSL ]
+
+
+[<ReflectedDefinition>][<Inline>]
+let sum3 a b c =
+    a + b + c
+
+[<ReflectedDefinition>][<Inline>]
+let condSum4 (a : float) (b : float) (c : float) (d : float) =
+    if a > 0.5 then
+        sum3 (b * 2.0) c d
+    else 
+        a
+        
+[<Fact>]
+let ``Nested Double Inline``() =
+    Setup.Run()
+
+    let frag (v : Vertex) =
+        fragment {
+            
+            let v = condSum4 (uniform?a) (uniform?b) (uniform?c) (uniform?d)
+
+            return V4d(v)
+        }
+        
+    GLSL.shouldCompile [ Effect.ofFunction frag ] 

--- a/src/Tests/FShade.GLSL.Tests/SimpleTests.fs
+++ b/src/Tests/FShade.GLSL.Tests/SimpleTests.fs
@@ -95,3 +95,79 @@ let ``PointSize shader``() =
 
 
 
+
+[<ReflectedDefinition>]
+let fillArray (array : Arr<N<10>, V4d>) denom = 
+    for i in 0 .. 9 do
+        array.[i] <- V4d(float i / denom)
+    
+
+[<Fact>]
+let ``Fill Array with Function``() =
+    Setup.Run()
+
+    let frag (v : Vertex) =
+        fragment {
+            let array = Arr<N<10>, V4d>()
+
+            10.0 |> fillArray array
+
+            // using this instead works
+            // let array = fillArray array 10
+
+            return array.[uniform?color]
+        }
+        
+    let expectedFillArrayGLSL =
+        sprintf "
+void .*_fillArray_.*\(vec4 array\[10], float denom\)
+{
+    for\(int i = 0; \(i < 10\); i\+\+\)
+    {
+        array\[i] = vec4\(\(float\(i\) \/ denom\)\);
+    }
+}"
+
+    let expectedMainGLSL =
+        sprintf "
+    vec4 array\[10\];
+    .*_fillArray_.*\(array, 10\.0\);
+    ColorsOut = array1\[color\]"
+
+                
+    GLSL.shouldCompileAndContainRegex [ Effect.ofFunction frag ] [ expectedFillArrayGLSL; expectedMainGLSL ]
+
+[<ReflectedDefinition>][<Inline>]
+let fillArrayInline (array : Arr<N<10>, V4d>) denom = 
+    for i in 0 .. 9 do
+        array.[i] <- V4d(float i / denom)
+    
+
+[<Fact>]
+let ``Fill Array with Inline Function``() =
+    Setup.Run()
+
+    let frag (v : Vertex) =
+        fragment {
+            let array = Arr<N<10>, V4d>()
+
+            10.0 |> fillArrayInline array 
+
+            // using this instead works
+            //fillArrayInline array 10.0
+
+            return array.[uniform?color]
+        }
+        
+    let expectedGLSL =
+        sprintf "
+    vec4 array\[10];
+    for\(int i = 0; \(i < 10\); i\+\+\)
+    {
+        array\[i\] = vec4\(\(float\(i\) \/ 10\.0\)\);
+    }
+    ColorsOut = array\[color\];"
+                
+    GLSL.shouldCompileAndContainRegex [ Effect.ofFunction frag ] [ expectedGLSL ]
+
+

--- a/src/Tests/FShade.GLSL.Tests/Utilities.fs
+++ b/src/Tests/FShade.GLSL.Tests/Utilities.fs
@@ -99,7 +99,31 @@ module GLSL =
                 | Success -> ()
                 | Warning w -> ()
                 | Error e -> failwithf "ERROR: %A" e
+                
 
+    let shouldContainRegex (shader : GLSLShader) (regexList : list<string>) = 
+
+        let notContained = regexList |> List.filter (fun s ->
+                if Regex.Match(shader.code, s).Success then
+                    false
+                else 
+                    true
+            )
+
+        if List.length notContained = 0 then
+            ()
+        else 
+            failwithf "ERROR: Compiled shader did not contain %A" notContained
+
+    let shouldCompileAndContainRegex (e : list<Effect>) (s : list<string>) =
+        let glsl, res = compile e
+        
+        for (stage, r) in res do
+            Console.WriteLine("{0}: {1}", stage, sprintf "%A" r)
+            match r with
+                | Success -> shouldContainRegex glsl s
+                | Warning w -> shouldContainRegex glsl s
+                | Error e -> failwithf "ERROR: %A" e
 
 type Setup() =
     static let initialized = ref false


### PR DESCRIPTION
This merge request adds to new test functions:  `shouldContainRegex ` `shouldCompileAndContainRegex`.
They are used to test some issues I came recently accross in FShade:

1) The pipe operater seems to cause problems
  `10.0 |> fillArrayInline array` creates wrong code while `fillArrayInline array 10.0` creates correct code.

2) A void function that fills an array creates wrong code, while when the array is returned, correct code is generated

3) Two nested inline functions which create a Stack Overlfow during shader compilation. 

See the pull request test code for more details. Two of the tests fail currently.