### PR TITLE
Remove parent reference from GLSLShaderInterface

### DIFF
--- a/src/Libs/FShade.GLSL/Assembler.fs
+++ b/src/Libs/FShade.GLSL/Assembler.fs
@@ -399,7 +399,6 @@ module Interface =
 
     let private emptyShader =
         {
-            program                         = Unchecked.defaultof<_>
             shaderStage                     = ShaderStage.Compute
             shaderEntry                     = ""
 
@@ -1950,25 +1949,6 @@ module Assembler =
             | CStructDef(name, fields) ->
                 let fields = fields |> List.map (fun (t, n) -> sprintf "%s %s;" (assembleType rev t).Name (glslName n).Name) |> String.concat "\r\n"
                 sprintf "struct %s\r\n{\r\n%s\r\n};" (glslName name).Name (String.indent fields)
-    
-    module private Reflection =
-        open System.Reflection
-        open Aardvark.Base.IL
-
-        let setShaderParent : GLSLShaderInterface -> GLSLProgramInterface -> unit =
-            let tShader = typeof<GLSLShaderInterface>
-            let fParent = tShader.GetField("program@", System.Reflection.BindingFlags.NonPublic ||| System.Reflection.BindingFlags.Instance)
-            if isNull fParent then
-                failwith "[FShade] internal error: cannot get parent field for GLSLShaderInterface"
-            cil {
-                do! IL.ldarg 0
-                do! IL.ldarg 1
-                do! IL.stfld fParent
-                do! IL.ret
-            }
-
-
-
 
     let assemble (backend : Backend) (m : CModule) =
         
@@ -2057,10 +2037,5 @@ module Assembler =
 
         let code = definitions.Run(&state) |> String.concat "\r\n\r\n"
         let iface = LayoutStd140.apply state.ifaceNew
-
-        // unsafely mutate the shader's parent
-        iface.shaders |> GLSLProgramShaders.iter (fun shader ->
-            Reflection.setShaderParent shader iface
-        )
 
         { code = code; iface = iface }

--- a/src/Libs/FShade.GLSL/UniformBufferLayout.fs
+++ b/src/Libs/FShade.GLSL/UniformBufferLayout.fs
@@ -494,7 +494,6 @@ module private Tools =
 [<CustomEquality; NoComparison>]
 type GLSLShaderInterface =
     {
-        program                      : GLSLProgramInterface
         shaderStage                  : ShaderStage
         shaderEntry                  : string
         shaderInputs                 : list<GLSLParameter>
@@ -823,8 +822,6 @@ module GLSLShaderInterface =
             ret = GLSLType.Void
         }
 
-
-    let inline program (i : GLSLShaderInterface) = i.program
     let inline stage (i : GLSLShaderInterface) = i.shaderStage
     let inline entry (i : GLSLShaderInterface) = i.shaderEntry
     let inline inputs (i : GLSLShaderInterface) = i.shaderInputs
@@ -1027,7 +1024,6 @@ module GLSLShaderInterface =
             |> MapExt.ofList
 
         {
-            program                      = Unchecked.defaultof<_>
             shaderStage                  = stage
             shaderEntry                  = entry
             shaderInputs                 = input
@@ -1308,22 +1304,6 @@ module GLSLProgramInterface =
                 MaxLod = maxLod
                 MinLod = minLod
                 MipLodBias = mipLodBias
-            }
-
-    module private Reflection =
-        open System.Reflection
-        open Aardvark.Base.IL
-
-        let setShaderParent : GLSLShaderInterface -> GLSLProgramInterface -> unit =
-            let tShader = typeof<GLSLShaderInterface>
-            let fParent = tShader.GetField("program@", System.Reflection.BindingFlags.NonPublic ||| System.Reflection.BindingFlags.Instance)
-            if isNull fParent then
-                failwith "[FShade] internal error: cannot get parent field for GLSLShaderInterface"
-            cil {
-                do! IL.ldarg 0
-                do! IL.ldarg 1
-                do! IL.stfld fParent
-                do! IL.ret
             }
 
     let internal serializeInternal (dst : BinaryWriter) (program : GLSLProgramInterface) =
@@ -1655,10 +1635,6 @@ module GLSLProgramInterface =
                 shaders = shaders
                 accelerationStructures = accelerationStructures
             }
-
-        for s in allShaders do 
-            Reflection.setShaderParent s result
-
 
         result
 


### PR DESCRIPTION
There is a circular reference between `GLSLProgramInterface` and `GLSLShaderInterface`, which is created by mutating the field of the immutable `GLSLShaderInterface` record via reflection. This is not clean and also seems to lead to problems in some scenarios (e.g. serialization).

Removed this parent reference, which wasn't used in FShade itself anyway. `Aardvark.Rendering.Vulkan` currently uses the parent field but can be worked around easily.